### PR TITLE
Fixing wrong/old url

### DIFF
--- a/rankmirrors
+++ b/rankmirrors
@@ -5,7 +5,7 @@ set -xe
 cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.backup
 
 {
-  curl -s 'https://www.archlinux.org/mirrorlist/?protocol=https&use_mirror_status=on' | sed -e 's/^#Server/Server/' -e '/^#/d' | rankmirrors -n 100 - > /etc/pacman.d/mirrorlist
+  curl -s 'https://archlinux.org/mirrorlist/?protocol=https&use_mirror_status=on' | sed -e 's/^#Server/Server/' -e '/^#/d' | rankmirrors -n 100 - > /etc/pacman.d/mirrorlist
 } || {
   cp /etc/pacman.d/mirrorlist.backup /etc/pacman.d/mirrorlist && exit 1
 }


### PR DESCRIPTION
It looks like arch changed the url scheme, because requests to `https://www.archlinux.org/mirrorlist/?protocol=https&use_mirror_status=on` received 301 responses, which broke my mirrorlist file.  `https://archlinux.org/mirrorlist/?protocol=https&use_mirror_status=on` works though.